### PR TITLE
[TN-30] call the realtor api endpoint within an endpoint in our backend -- connected to frontend button

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -33,9 +33,9 @@ app.get('/', function(req, res, next) {
     res.send(JSON.stringify());
 });
 
-app.get('/listingsQuery', function(req, res){
+app.post('/listingsQuery', function(req, res){
 
-    var postal_code = req.headers.postal_code;
+    var postal_code = req.body.postal_code;
 
     var unirest = require("unirest");
 
@@ -51,14 +51,14 @@ app.get('/listingsQuery', function(req, res){
     
     req.headers({
         "x-rapidapi-host": "realtor.p.rapidapi.com",
-        "x-rapidapi-key": "",
+        "x-rapidapi-key": "7ef5b92b24mshd40be68071889bbp123f2cjsn0f27be929a49",
         "useQueryString": true
     });
     
     
-    req.end(function (res1) {
-        if (res1.error) res.status(400);
-        res.send(JSON.stringify(res1.body));
+    req.end(function (realtorRes) {
+        if (realtorRes.error) res.status(400);
+        res.send(JSON.stringify(realtorRes.body));
     });
 });
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -33,6 +33,35 @@ app.get('/', function(req, res, next) {
     res.send(JSON.stringify());
 });
 
+app.get('/listingsQuery', function(req, res, next){
+
+    var postal_code = req.headers.postal_code;
+
+    var unirest = require("unirest");
+
+    var req = unirest("GET", "https://realtor.p.rapidapi.com/properties/v2/list-for-sale");
+    
+    req.query({
+        "sort": "relevance",
+        "limit": "200",
+        "offset": "0",
+        "postal_code": postal_code //94114 for testing
+
+    });
+    
+    req.headers({
+        "x-rapidapi-host": "realtor.p.rapidapi.com",
+        "x-rapidapi-key": "be8ed8dc23mshf10fecfd09dac6ap114951jsne2bd1b3b7515",
+        "useQueryString": true
+    });
+    
+    
+    req.end(function (res1) {
+        if (res1.error) res.status(400).send("bad request");
+        res.status(200).send(JSON.stringify(res1.body));
+    });
+});
+
 app.post('/radiusQuery', function(req, res, next){
     var lat = req.body.lat;
     var long = req.body.long;

--- a/backend/index.js
+++ b/backend/index.js
@@ -51,7 +51,7 @@ app.get('/listingsQuery', function(req, res){
     
     req.headers({
         "x-rapidapi-host": "realtor.p.rapidapi.com",
-        "x-rapidapi-key": "be8ed8dc23mshf10fecfd09dac6ap114951jsne2bd1b3b7515",
+        "x-rapidapi-key": "",
         "useQueryString": true
     });
     

--- a/backend/index.js
+++ b/backend/index.js
@@ -51,7 +51,7 @@ app.post('/listingsQuery', function(req, res){
     
     req.headers({
         "x-rapidapi-host": "realtor.p.rapidapi.com",
-        "x-rapidapi-key": "7ef5b92b24mshd40be68071889bbp123f2cjsn0f27be929a49",
+        "x-rapidapi-key": "",
         "useQueryString": true
     });
     

--- a/backend/index.js
+++ b/backend/index.js
@@ -33,7 +33,7 @@ app.get('/', function(req, res, next) {
     res.send(JSON.stringify());
 });
 
-app.get('/listingsQuery', function(req, res, next){
+app.get('/listingsQuery', function(req, res){
 
     var postal_code = req.headers.postal_code;
 
@@ -62,7 +62,7 @@ app.get('/listingsQuery', function(req, res, next){
     });
 });
 
-app.post('/radiusQuery', function(req, res, next){
+app.post('/radiusQuery', function(req, res){
     var lat = req.body.lat;
     var long = req.body.long;
     const ddbGeo = require('dynamodb-geo');

--- a/backend/index.js
+++ b/backend/index.js
@@ -57,8 +57,8 @@ app.get('/listingsQuery', function(req, res){
     
     
     req.end(function (res1) {
-        if (res1.error) res.status(400).send("bad request");
-        res.status(200).send(JSON.stringify(res1.body));
+        if (res1.error) res.status(400);
+        res.send(JSON.stringify(res1.body));
     });
 });
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -23,10 +23,44 @@
         "negotiator": "0.6.2"
       }
     },
+    "ajv": {
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
+      "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "async": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+      "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "aws-sdk": {
       "version": "2.738.0",
@@ -44,10 +78,28 @@
         "xml2js": "0.4.19"
       }
     },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
+      "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA=="
+    },
     "base64-js": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
       "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
     },
     "body-parser": {
       "version": "1.19.0",
@@ -81,6 +133,19 @@
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
       "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
     },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "combined-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+      "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
+      "requires": {
+        "delayed-stream": "0.0.5"
+      }
+    },
     "content-disposition": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
@@ -104,6 +169,19 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -116,6 +194,11 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-6.0.0.tgz",
       "integrity": "sha1-T9WNBjfzb9vBq6EyC8Pyzug8oPI="
+    },
+    "delayed-stream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+      "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8="
     },
     "depd": {
       "version": "1.1.2",
@@ -140,6 +223,15 @@
         "@types/decimal.js": "^0.0.30",
         "@types/long": ">=3",
         "nodes2ts": "^1.1.10"
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "ee-first": {
@@ -204,6 +296,26 @@
         "vary": "~1.1.2"
       }
     },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+    },
     "finalhandler": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
@@ -218,6 +330,36 @@
         "unpipe": "~1.0.0"
       }
     },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+      "integrity": "sha1-Jvi8JtpkQOKZy9z7aQNcT3em5GY=",
+      "requires": {
+        "async": "~0.9.0",
+        "combined-stream": "~0.0.4",
+        "mime-types": "~2.0.3"
+      },
+      "dependencies": {
+        "mime-db": {
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+          "integrity": "sha1-PQxjGA9FjrENMlqqN9fFiuMS6dc="
+        },
+        "mime-types": {
+          "version": "2.0.14",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+          "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
+          "requires": {
+            "mime-db": "~1.12.0"
+          }
+        }
+      }
+    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -227,6 +369,28 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
+    "har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "requires": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      }
     },
     "http-errors": {
       "version": "1.7.2",
@@ -238,6 +402,16 @@
         "setprototypeof": "1.1.1",
         "statuses": ">= 1.5.0 < 2",
         "toidentifier": "1.0.0"
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "iconv-lite": {
@@ -263,15 +437,56 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
     },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
     "jmespath": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
     },
     "long": {
       "version": "3.2.0",
@@ -330,6 +545,11 @@
         "long": "^3.2.0"
       }
     },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+    },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -348,6 +568,11 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
     "proxy-addr": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -356,6 +581,11 @@
         "forwarded": "~0.1.2",
         "ipaddr.js": "1.9.1"
       }
+    },
+    "psl": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
     "punycode": {
       "version": "1.3.2",
@@ -386,6 +616,63 @@
         "http-errors": "1.7.2",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
+      }
+    },
+    "request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "combined-stream": {
+          "version": "1.0.8",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+          "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+          "requires": {
+            "delayed-stream": "~1.0.0"
+          }
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+        },
+        "form-data": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+        }
       }
     },
     "safe-buffer": {
@@ -446,6 +733,22 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
     },
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
     "statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
@@ -456,6 +759,35 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
+    "tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "requires": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+        }
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+    },
     "type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -465,10 +797,42 @@
         "mime-types": "~2.1.24"
       }
     },
+    "unirest": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/unirest/-/unirest-0.6.0.tgz",
+      "integrity": "sha512-BdYdcYJHXACqZ53k8Zz7QlNK/1W/HjCZlmg1OaaN/oTSp4FTWh0upXGSJsG88PljDBpSrNc2R649drasUA9NEg==",
+      "requires": {
+        "form-data": "^0.2.0",
+        "mime": "^2.4.0",
+        "request": "^2.88.0"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "2.4.6",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
+        }
+      }
+    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "uri-js": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
+      "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
+      "requires": {
+        "punycode": "^2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+        }
+      }
     },
     "url": {
       "version": "0.10.3",
@@ -493,6 +857,16 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
     },
     "xml2js": {
       "version": "0.4.19",

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,6 +26,7 @@
     "dotenv": "^8.2.0",
     "dynamodb-geo": "^0.4.0",
     "express": "^4.17.1",
+    "unirest": "^0.6.0",
     "uuid": "^3.0.1"
   }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13534,6 +13534,59 @@
         "imurmurhash": "^0.1.4"
       }
     },
+    "unirest": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/unirest/-/unirest-0.6.0.tgz",
+      "integrity": "sha512-BdYdcYJHXACqZ53k8Zz7QlNK/1W/HjCZlmg1OaaN/oTSp4FTWh0upXGSJsG88PljDBpSrNc2R649drasUA9NEg==",
+      "requires": {
+        "form-data": "^0.2.0",
+        "mime": "^2.4.0",
+        "request": "^2.88.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+        },
+        "combined-stream": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+          "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
+          "requires": {
+            "delayed-stream": "0.0.5"
+          }
+        },
+        "delayed-stream": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+          "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8="
+        },
+        "form-data": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+          "integrity": "sha1-Jvi8JtpkQOKZy9z7aQNcT3em5GY=",
+          "requires": {
+            "async": "~0.9.0",
+            "combined-stream": "~0.0.4",
+            "mime-types": "~2.0.3"
+          }
+        },
+        "mime-db": {
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+          "integrity": "sha1-PQxjGA9FjrENMlqqN9fFiuMS6dc="
+        },
+        "mime-types": {
+          "version": "2.0.14",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+          "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
+          "requires": {
+            "mime-db": "~1.12.0"
+          }
+        }
+      }
+    },
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
     "react-table": "^7.5.0",
     "react-test-renderer": "^16.13.1",
     "reactstrap": "^8.5.1",
-    "styled-components": "^4.4.1",
+    "styled-components": "^4.4.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,6 @@
     "react-test-renderer": "^16.13.1",
     "reactstrap": "^8.5.1",
     "styled-components": "^4.4.1",
-    "unirest": "^0.6.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "bootstrap": "^4.5.0",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",
+    "proxy": "http://localhost:3000",
     "react": "^16.13.1",
     "react-bootstrap": "^1.0.0-beta.14",
     "react-dom": "^16.13.1",
@@ -19,7 +20,8 @@
     "react-table": "^7.5.0",
     "react-test-renderer": "^16.13.1",
     "reactstrap": "^8.5.1",
-    "styled-components": "^4.4.1"
+    "styled-components": "^4.4.1",
+    "unirest": "^0.6.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/frontend/src/components/UserInput/UserInput.js
+++ b/frontend/src/components/UserInput/UserInput.js
@@ -17,18 +17,25 @@ export class UserInput extends Component {
     handleChange(event) { this.setState({ zip: event.target.value }); }
 
     callApi() {
-            var unirest = require('unirest');
-            var req = unirest('GET', 'http://localhost:3000/listingsQuery');
+            var myHeaders = new Headers();
+            myHeaders.append("postal_code", this.state.zip);
+            myHeaders.append("Content-Type", "application/json");
 
-            req.headers({
-                'postal_code': this.state.zip
-            })
-            req.send("")
-            req.end(function (res) { 
-                if (res.error) throw new Error(res.error); 
-                console.log(res.raw_body);
-            });
+            var raw = JSON.stringify({"postal_code":this.state.zip});
+
+            var requestOptions = {
+            method: 'POST',
+            headers: myHeaders,
+            body: raw,
+            redirect: 'follow'
+            };
+
+            fetch("http://localhost:3000/listingsQuery", requestOptions)
+            .then(response => response.text())
+            .then(result => console.log(result))
+            .catch(error => console.log('error', error));
     }
+
     render() {
         return (
             <Container className="UserInput">

--- a/frontend/src/components/UserInput/UserInput.js
+++ b/frontend/src/components/UserInput/UserInput.js
@@ -17,7 +17,17 @@ export class UserInput extends Component {
     handleChange(event) { this.setState({ zip: event.target.value }); }
 
     callApi() {
-        console.log(this.state)
+            var unirest = require('unirest');
+            var req = unirest('GET', 'http://localhost:3000/listingsQuery');
+
+            req.headers({
+                'postal_code': this.state.zip
+            })
+            req.send("")
+            req.end(function (res) { 
+                if (res.error) throw new Error(res.error); 
+                console.log(res.raw_body);
+            });
     }
     render() {
         return (


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines. For the guidelines check the README.
- [ ] Tests for the changes have been added (for bug fixes / features). As we discussed this is optional but encouraged.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  - there is now an api endpoint attached to landing page button


* **What is the current behavior?** (You can also link to an open issue here)
  - there is no endpoint to access the rental listings and the button on the landing page just logs the state


* **What is the new behavior (if this is a feature change)?**
  - the button now calls our listingsQuery api endpoint which calls the realtor api and then logs the raw body of the request (listings in the area of the given zip code)


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
  - yes, unirest must be installed on both the frontend and backend and in order to run both locally we must set a proxy in our package.json file. We must then run the frontend first then the backend (recompiling the frontend will require the backend to be stopped and restarted, at least in my experience)
  - a realtor api key is required


* **Other information**:
